### PR TITLE
build: drop the test from the release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,16 +4,8 @@ on:
   release:
     types: [created]
 
-env:
-  EARTHENGINE_SERVICE_ACCOUNT: ${{ secrets.EARTHENGINE_SERVICE_ACCOUNT }}
-  EARTHENGINE_PROJECT: ${{ secrets.EARTHENGINE_PROJECT }}
-
 jobs:
-  tests:
-    uses: ./.github/workflows/unit.yaml
-
   deploy:
-    needs: [tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I guess the secrets content is not available from the templates making it impossible to give the content of EARTHENGINE_SERVICE_ACCOUNT to the tests methods.