### PR TITLE
fix: deal with ImageCollection as with Folder

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -169,7 +169,8 @@ By default the test folder tree is empty and will be deleted at the end of the t
 You can decide to populate it with some assets that will be used in your tests.
 
 To do so customize the ``gee_folder_structure`` fixture in your ``conftest.py`` file.
-This fixture is a ``dict`` that will be used to create the folder tree in GEE. As shown in the following example you can add subfolder and assets to this tree.
+This fixture is a ``dict`` that will be used to create the folder tree in GEE.
+First you can create containers assets (namely folders or image collections) to store your assets. These container are simply marked as keys in the dict and specify their types after a "::" symbol as shown in the following example.
 assets need to be ``ee.Image`` or ``ee.FeatureCollection`` objects and remain small as the creation operation is taken care of by the plugin.
 Specifically for ``ee.Image`` objects, please use the ``clipToBoundsAndScale`` method to make sure the asset has a geometry and a scale.
 
@@ -184,9 +185,13 @@ Specifically for ``ee.Image`` objects, please use the ``clipToBoundsAndScale`` m
         """Override the default test folder structure."""
         point = ee.Geometry.Point([0, 0])
         return {
-            "folder": {
+            "folder::Folder": {
                 "image": ee.Image(1).clipToBoundsAndScale(point.buffer(100), scale=30),
                 "fc": ee.FeatureCollection(point),
+            },
+            "image_collection::ImageCollection": {
+                "image1": ee.Image(1).clipToBoundsAndScale(point.buffer(100), scale=30),
+                "image2": ee.Image(1).clipToBoundsAndScale(point.buffer(100), scale=30),
             }
         }
 
@@ -197,7 +202,10 @@ Which will render in your GEE account as:
     8d98a5be574041a6a54d6def9d915c67/
     └── folder/
         ├── fc (FeatureCollection)
-        └── image (ImageCollection)
+        └── image (Image)
+    └── image_collection/ (ImageCollection)
+        ├── image1 (Image)
+        └── image2 (Image)
 
 Customize the root folder
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pytest_gee/utils.py
+++ b/pytest_gee/utils.py
@@ -79,7 +79,7 @@ def get_assets(folder: Union[str, Path]) -> List[dict]:
     def _recursive_get(folder, asset_list):
         for asset in ee.data.listAssets({"parent": folder})["assets"]:
             asset_list.append(asset)
-            if asset["type"] == "FOLDER":
+            if asset["type"] in ["FOLDER", "IMAGE_COLLECTION"]:
                 asset_list = _recursive_get(asset["name"], asset_list)
         return asset_list
 
@@ -145,10 +145,8 @@ def _create_container(asset_request: str) -> str:
     asset_id, asset_type = parts[:2]
 
     # create the container
-    if asset_type == "FOLDER":
-        ee.data.createFolder(asset_id)
-    elif asset_type == "IMAGE_COLLECTION":
-        ee.data.createAsset(asset_id, {"type": "IMAGE_COLLECTION"})
+    if asset_type in ["Folder", "ImageCollection"]:
+        ee.data.createAsset({"type": asset_type}, asset_id)
     else:
         raise ValueError(f"Asset type {asset_type} is not supported.")
 
@@ -234,7 +232,7 @@ def delete_assets(asset_id: Union[str, Path], dry_run: bool = True) -> list:
     # identify the type of asset
     asset_info = ee.data.getAsset(asset_id)
 
-    if asset_info["type"] == "FOLDER":
+    if asset_info["type"] in ["FOLDER", "IMAGE_COLLECTION"]:
 
         # get all the assets
         asset_list = get_assets(folder=asset_id)
@@ -249,6 +247,7 @@ def delete_assets(asset_id: Union[str, Path], dry_run: bool = True) -> list:
 
         # delete all items starting from the more nested ones
         assets_ordered = dict(sorted(assets_ordered.items(), reverse=True))
+        print(assets_ordered)
         for lvl in assets_ordered:
             for i in assets_ordered[lvl]:
                 delete(i["name"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,12 @@ def gee_folder_structure():
     """Override the default test folder structure."""
     point = ee.Geometry.Point([0, 0])
     return {
-        "folder": {
+        "folder::Folder": {
             "image": ee.Image(1).clipToBoundsAndScale(point.buffer(100), scale=30),
             "fc": ee.FeatureCollection(point),
-        }
+        },
+        "ic::ImageCollection": {
+            "image1": ee.Image(1).clipToBoundsAndScale(point.buffer(100), scale=30),
+            "image2": ee.Image(1).clipToBoundsAndScale(point.buffer(100), scale=30),
+        },
     }

--- a/tests/test_pytest_gee.py
+++ b/tests/test_pytest_gee.py
@@ -18,9 +18,12 @@ def test_gee_init():
 def test_structure(gee_folder_structure):
     """Test the structure fixture."""
     assert isinstance(gee_folder_structure, dict)
-    assert "folder" in gee_folder_structure
-    assert "image" in gee_folder_structure["folder"]
-    assert "fc" in gee_folder_structure["folder"]
+    assert "folder::Folder" in gee_folder_structure
+    assert "image" in gee_folder_structure["folder::Folder"]
+    assert "fc" in gee_folder_structure["folder::Folder"]
+    assert "ic::ImageCollection" in gee_folder_structure
+    assert "image1" in gee_folder_structure["ic::ImageCollection"]
+    assert "image2" in gee_folder_structure["ic::ImageCollection"]
 
 
 def test_init_tree(gee_folder_root, gee_test_folder):


### PR DESCRIPTION
Fix #27 

The previous implementation was enable to deal with imageCollection objects. As such if someone wanted to test an ImageCollection asset he was force to run the ImageCollection creation from the code instead of the tree dict description. 

In this PR I introduced a new type keyword that need to be specified when crzating containers "IMAGE_COLLECTION" or "FOLDER". like in the documentation example: 

```python
{
  "folder::Folder": {
    "image": ee.Image(1).clipToBoundsAndScale(point.buffer(100), scale=30),
    "fc": ee.FeatureCollection(point),
  },
  "image_collection::ImageCollection": {
    "image1": ee.Image(1).clipToBoundsAndScale(point.buffer(100), scale=30),
    "image2": ee.Image(1).clipToBoundsAndScale(point.buffer(100), scale=30),
  }
}
```

Only "Folder" and ImageCollection" types are supported (and to my knowledge they are currently the only 2 types of containers)

To avoid non-regression an non specified container type will be treated as a Folder. 