### PR TITLE
fix: avoid a bug when the token is saved in an rdt environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
   "coverage",
 ]
 doc = [
-  "sphinx>=6.2.1",
+  "sphinx>=6.2.1,<8",
   "pydata-sphinx-theme",
   "sphinx-copybutton",
   "sphinx-design",

--- a/pytest_gee/__init__.py
+++ b/pytest_gee/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Union
@@ -32,8 +33,16 @@ def init_ee_from_token():
     """
     if "EARTHENGINE_TOKEN" in os.environ:
 
-        # write the token to the appropriate folder
+        # read the ee_token from the environment variable
         ee_token = os.environ["EARTHENGINE_TOKEN"]
+
+        # small workaround to remove the quotes around the token
+        # related to a very specific issue with readthedocs interface
+        # https://github.com/readthedocs/readthedocs.org/issues/10553
+        pattern = re.compile(r"^'[^']*'$")
+        ee_token = ee_token[1:-1] if pattern.match(ee_token) else ee_token
+
+        # write the token to the appropriate folder
         credential_folder_path = Path.home() / ".config" / "earthengine"
         credential_folder_path.mkdir(parents=True, exist_ok=True)
         credential_file_path = credential_folder_path / "credentials"


### PR DESCRIPTION
everything is in the title