### PR TITLE
fix: rely on the vanilla `wait_for_task`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
 
   # Prevent committing inline conflict markers
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
         stages: [pre-commit]

--- a/pytest_gee/__init__.py
+++ b/pytest_gee/__init__.py
@@ -82,7 +82,9 @@ def init_ee_from_service_account():
         # private key data
         ee_user = json.loads(private_key)["client_email"]
         credentials = ee.ServiceAccountCredentials(ee_user, key_data=private_key)
-        ee.Initialize(credentials=credentials, http_transport=httplib2.Http())
+        ee.Initialize(
+            credentials=credentials, project=credentials.project_id, http_transport=httplib2.Http()
+        )
 
     elif "EARTHENGINE_PROJECT" in os.environ:
         # if the user is in local development the authentication should already be available

--- a/pytest_gee/__init__.py
+++ b/pytest_gee/__init__.py
@@ -11,8 +11,7 @@ from typing import Union
 import ee
 import httplib2
 from deprecated.sphinx import deprecated
-
-from .utils import wait_for_task
+from ee.cli.utils import wait_for_task
 
 __version__ = "0.8.0"
 __author__ = "Pierrick Rambaud"

--- a/pytest_gee/__init__.py
+++ b/pytest_gee/__init__.py
@@ -82,9 +82,7 @@ def init_ee_from_service_account():
         # private key data
         ee_user = json.loads(private_key)["client_email"]
         credentials = ee.ServiceAccountCredentials(ee_user, key_data=private_key)
-        ee.Initialize(
-            credentials=credentials, project=credentials.project_id, http_transport=httplib2.Http()
-        )
+        ee.Initialize(credentials=credentials, http_transport=httplib2.Http())
 
     elif "EARTHENGINE_PROJECT" in os.environ:
         # if the user is in local development the authentication should already be available

--- a/pytest_gee/__init__.py
+++ b/pytest_gee/__init__.py
@@ -47,7 +47,7 @@ def init_ee_from_token():
         credential_file_path = credential_folder_path / "credentials"
         credential_file_path.write_text(ee_token)
 
-    project_id = os.environ.get("EARTHENGINE_PROJECT", ee.data._cloud_api_user_project)
+    project_id = os.environ.get("EARTHENGINE_PROJECT")
     if project_id is None:
         raise ValueError(
             "The project name cannot be detected."

--- a/pytest_gee/plugin.py
+++ b/pytest_gee/plugin.py
@@ -24,15 +24,7 @@ def gee_hash():
 @pytest.fixture(scope="session")
 def gee_folder_root():
     """Link to the root folder of the connected account."""
-    # The credential information cannot be reached from
-    # the ee API as reported in https://issuetracker.google.com/issues/325020447
     project_id = get_state().cloud_api_user_project
-    # project_id = os.environ.get("EARTHENGINE_PROJECT", get_state().cloud_api_user_project)
-    # if project_id is None:
-    #     raise ValueError(
-    #         "The project name cannot be detected."
-    #         "Please set the EARTHENGINE_PROJECT environment variable."
-    #     )
     return Path(f"projects/{project_id}/assets")
 
 

--- a/pytest_gee/plugin.py
+++ b/pytest_gee/plugin.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import uuid
 from pathlib import Path
 
@@ -27,13 +26,13 @@ def gee_folder_root():
     """Link to the root folder of the connected account."""
     # The credential information cannot be reached from
     # the ee API as reported in https://issuetracker.google.com/issues/325020447
-    # project_id = get_state().cloud_api_user_project
-    project_id = os.environ.get("EARTHENGINE_PROJECT", get_state().cloud_api_user_project)
-    if project_id is None:
-        raise ValueError(
-            "The project name cannot be detected."
-            "Please set the EARTHENGINE_PROJECT environment variable."
-        )
+    project_id = get_state().cloud_api_user_project
+    # project_id = os.environ.get("EARTHENGINE_PROJECT", get_state().cloud_api_user_project)
+    # if project_id is None:
+    #     raise ValueError(
+    #         "The project name cannot be detected."
+    #         "Please set the EARTHENGINE_PROJECT environment variable."
+    #     )
     return Path(f"projects/{project_id}/assets")
 
 

--- a/pytest_gee/plugin.py
+++ b/pytest_gee/plugin.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import os
 import uuid
 from pathlib import Path
 
-import ee
 import pytest
+from ee._state import get_state
 
 from . import utils
 from .dictionary_regression import DictionaryFixture
@@ -27,12 +26,13 @@ def gee_folder_root():
     """Link to the root folder of the connected account."""
     # The credential information cannot be reached from
     # the ee API as reported in https://issuetracker.google.com/issues/325020447
-    project_id = os.environ.get("EARTHENGINE_PROJECT", ee.data._cloud_api_user_project)
-    if project_id is None:
-        raise ValueError(
-            "The project name cannot be detected."
-            "Please set the EARTHENGINE_PROJECT environment variable."
-        )
+    project_id = get_state().cloud_api_user_project
+    # project_id = os.environ.get("EARTHENGINE_PROJECT", ee.data._cloud_api_user_project)
+    # if project_id is None:
+    #     raise ValueError(
+    #         "The project name cannot be detected."
+    #         "Please set the EARTHENGINE_PROJECT environment variable."
+    #     )
     return Path(f"projects/{project_id}/assets")
 
 

--- a/pytest_gee/plugin.py
+++ b/pytest_gee/plugin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import uuid
 from pathlib import Path
 
@@ -26,13 +27,13 @@ def gee_folder_root():
     """Link to the root folder of the connected account."""
     # The credential information cannot be reached from
     # the ee API as reported in https://issuetracker.google.com/issues/325020447
-    project_id = get_state().cloud_api_user_project
-    # project_id = os.environ.get("EARTHENGINE_PROJECT", ee.data._cloud_api_user_project)
-    # if project_id is None:
-    #     raise ValueError(
-    #         "The project name cannot be detected."
-    #         "Please set the EARTHENGINE_PROJECT environment variable."
-    #     )
+    # project_id = get_state().cloud_api_user_project
+    project_id = os.environ.get("EARTHENGINE_PROJECT", get_state().cloud_api_user_project)
+    if project_id is None:
+        raise ValueError(
+            "The project name cannot be detected."
+            "Please set the EARTHENGINE_PROJECT environment variable."
+        )
     return Path(f"projects/{project_id}/assets")
 
 

--- a/pytest_gee/utils.py
+++ b/pytest_gee/utils.py
@@ -7,11 +7,9 @@
 
 from __future__ import annotations
 
-import datetime
 import json
 import os
 import re
-import time
 from functools import partial
 from pathlib import Path, PurePosixPath
 from typing import List, Optional, Union
@@ -21,9 +19,9 @@ import ee
 import pytest
 import yaml
 from deprecated.sphinx import deprecated
+from ee.cli.utils import wait_for_task
 from pytest_regressions.common import check_text_files, perform_regression_check
 from pytest_regressions.data_regression import RegressionYamlDumper
-from ee.cli.utils import wait_for_task
 
 TASK_FINISHED_STATES: tuple[str, str, str] = (
     ee.batch.Task.State.COMPLETED,

--- a/pytest_gee/utils.py
+++ b/pytest_gee/utils.py
@@ -23,51 +23,13 @@ import yaml
 from deprecated.sphinx import deprecated
 from pytest_regressions.common import check_text_files, perform_regression_check
 from pytest_regressions.data_regression import RegressionYamlDumper
+from ee.cli.utils import wait_for_task
 
 TASK_FINISHED_STATES: tuple[str, str, str] = (
     ee.batch.Task.State.COMPLETED,
     ee.batch.Task.State.FAILED,
     ee.batch.Task.State.CANCELLED,
 )
-
-
-def wait_for_task(task_id: str, timeout: float, log_progress: bool = True):
-    """Waits for the specified task to finish, or a timeout to occur.
-
-    The method is a workaround for for a warning that we see in all our tests and pipeline.
-    It's reported to Google team here: https://issuetracker.google.com/issues/329560181
-
-    Args:
-      task_id: The ID of the task to wait for.
-      timeout: The maximum time to wait, in seconds.
-      log_progress: Whether to log the progress of the task while waiting.
-    """
-    start = time.time()
-    elapsed = 0.0
-    last_check = 0.0
-    while True:
-        elapsed = time.time() - start
-        status = ee.data.getTaskStatus(task_id)[0]
-        state = status["state"]
-        if state in TASK_FINISHED_STATES:
-            error_message = status.get("error_message", None)
-            print("Task %s ended at state: %s after %.2f seconds" % (task_id, state, elapsed))
-            if error_message:
-                raise ee.ee_exception.EEException("Error: %s" % error_message)
-            return
-        if log_progress and elapsed - last_check >= 30:
-            print(
-                "[{:%H:%M:%S}] Current state for task {}: {}".format(
-                    datetime.datetime.now(), task_id, state
-                )
-            )
-            last_check = elapsed
-        remaining = timeout - elapsed
-        if remaining > 0:
-            time.sleep(min(10, remaining))
-        else:
-            break
-    print("Wait for task %s timed out after %.2f seconds" % (task_id, elapsed))
 
 
 @deprecated(version="0.3.5", reason="Use the vanilla GEE ``wait_for_task`` function instead.")


### PR DESCRIPTION
Since version 1.6.12 the problem of the call to deprecated function is solved (13/10/2025).